### PR TITLE
feat: add patches with limesurvey variables in the LMS settings

### DIFF
--- a/tutorlimesurvey/patches/openedx-lms-development-settings
+++ b/tutorlimesurvey/patches/openedx-lms-development-settings
@@ -1,0 +1,2 @@
+LIMESURVEY_URL = "http://{{ LIMESURVEY_HOST }}:8082"
+LIMESURVEY_INTERNAL_API = "http://limesurvey:{{ LIMESURVEY_PORT }}/admin/remotecontrol"

--- a/tutorlimesurvey/patches/openedx-lms-production-settings
+++ b/tutorlimesurvey/patches/openedx-lms-production-settings
@@ -1,0 +1,2 @@
+LIMESURVEY_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LIMESURVEY_HOST }}"
+LIMESURVEY_INTERNAL_API = "http://limesurvey:{{ LIMESURVEY_PORT }}/admin/remotecontrol"


### PR DESCRIPTION
### Description

This PR adds new LimeSurvey variables in the LMS settings of development and production. This variables are used in the `xblock-limesurvey`.

### How to test
1. Install this branch in your environment.
2. Execute `tutor config save`
3. The variables should be in the settings of development and production.
