### PR TITLE
feat: add support for running limesurvey outside local network

### DIFF
--- a/tutorlimesurvey/patches/caddyfile
+++ b/tutorlimesurvey/patches/caddyfile
@@ -1,4 +1,6 @@
+{% if RUN_LIMESURVEY %}
 # Limesurvey
 {{ LIMESURVEY_HOST }}{$default_site_port} {
     import proxy "limesurvey:{{ LIMESURVEY_PORT }}"
 }
+{% endif %}

--- a/tutorlimesurvey/patches/k8s-deployments
+++ b/tutorlimesurvey/patches/k8s-deployments
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -59,3 +60,4 @@ spec:
           configMap:
             name: limesurvey-configmap
         {% endif %}
+{% endif %}

--- a/tutorlimesurvey/patches/k8s-jobs
+++ b/tutorlimesurvey/patches/k8s-jobs
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -29,3 +30,4 @@ spec:
               value: {{ LIMESURVEY_DB_PASSWORD }}
             - name: LIMESURVEY_DB_USER
               value: {{ LIMESURVEY_DB_USER }}
+{% endif %}

--- a/tutorlimesurvey/patches/k8s-services
+++ b/tutorlimesurvey/patches/k8s-services
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 ---
 apiVersion: v1
 kind: Service
@@ -12,3 +13,4 @@ spec:
       protocol: TCP
   selector:
     app.kubernetes.io/name: limesurvey
+{% endif %}

--- a/tutorlimesurvey/patches/k8s-volumes
+++ b/tutorlimesurvey/patches/k8s-volumes
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -37,3 +38,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
+{% endif %}

--- a/tutorlimesurvey/patches/kustomization-configmapgenerator
+++ b/tutorlimesurvey/patches/kustomization-configmapgenerator
@@ -1,4 +1,4 @@
-{% if LIMESURVEY_CONFIG %}
+{% if LIMESURVEY_CONFIG and RUN_LIMESURVEY %}
 - name: limesurvey-configmap
   files:
     - plugins/limesurvey/apps/applications/config/config.php

--- a/tutorlimesurvey/patches/local-docker-compose-dev-services
+++ b/tutorlimesurvey/patches/local-docker-compose-dev-services
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 limesurvey:
   image: {{ LIMESURVEY_DOCKER_IMAGE }}
   ports:
@@ -18,3 +19,4 @@ limesurvey:
   restart: unless-stopped
   depends_on:
     - mysql
+{% endif %}

--- a/tutorlimesurvey/patches/local-docker-compose-services
+++ b/tutorlimesurvey/patches/local-docker-compose-services
@@ -1,3 +1,4 @@
+{% if RUN_LIMESURVEY %}
 limesurvey:
   image: {{ LIMESURVEY_DOCKER_IMAGE }}
   ports:
@@ -18,3 +19,4 @@ limesurvey:
   restart: unless-stopped
   depends_on:
     - mysql
+{% endif %}

--- a/tutorlimesurvey/patches/openedx-lms-production-settings
+++ b/tutorlimesurvey/patches/openedx-lms-production-settings
@@ -1,2 +1,8 @@
-LIMESURVEY_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LIMESURVEY_HOST }}"
+LIMESURVEY_SCHEMA = "{{ "https" if ENABLE_HTTPS else "http" }}"
+LIMESURVEY_URL = f"{ LIMESURVEY_SCHEMA }://{{ LIMESURVEY_HOST }}"
+
+{% if RUN_LIMESURVEY %}
 LIMESURVEY_INTERNAL_API = "http://limesurvey:{{ LIMESURVEY_PORT }}/admin/remotecontrol"
+{% else %}
+LIMESURVEY_INTERNAL_API = f"{ LIMESURVEY_URL }/admin/remotecontrol"
+{% endif %}

--- a/tutorlimesurvey/plugin.py
+++ b/tutorlimesurvey/plugin.py
@@ -42,6 +42,7 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("LIMESURVEY_ADMIN_PASSWORD", "{{ 8|random_string }}"),
         ("LIMESURVEY_ADMIN_NAME", "Lime Administrator"),
         ("LIMESURVEY_ADMIN_EMAIL", "lime@lime.lime"),
+        ("RUN_LIMESURVEY", True),
     ]
 )
 


### PR DESCRIPTION
### Description
This PR adds support for running limesurvey outside a local network.

### How to test
For now, check the service and communication with the LMS are working in a local/dev environment, for tests for the k8s environment:
First consider, the LimeSurvey services are provisioned in Namespace A (valencia) and you're going to take the survey in an installation provisioned in Namespace B (seville):
1. Register as a student [this LMS](https://lms.seville.athena.edunext.link)
2. Enroll in the [LimeSurvey course](https://mfe.seville.athena.edunext.link/learning/course/course-v1:edunext+limesurvey-1+2023/home)
3. Take the survey
See how the iframe embedded inside the course is hosted in the valencia namespace: 
![image](https://github.com/eduNEXT/tutor-contrib-limesurvey/assets/64440265/20fa2e86-8930-4be4-910d-db110c5b991d)