### PR TITLE
refactor: remove config.php config since is not overridable

### DIFF
--- a/tutorlimesurvey/patches/k8s-deployments
+++ b/tutorlimesurvey/patches/k8s-deployments
@@ -55,9 +55,4 @@ spec:
         - name: limesurvey-config
           persistentVolumeClaim:
             claimName: limesurvey-config
-        {% if LIMESURVEY_CONFIG %}
-        - name: limesurvey-configmap
-          configMap:
-            name: limesurvey-configmap
-        {% endif %}
 {% endif %}

--- a/tutorlimesurvey/patches/kustomization-configmapgenerator
+++ b/tutorlimesurvey/patches/kustomization-configmapgenerator
@@ -1,8 +1,0 @@
-{% if LIMESURVEY_CONFIG and RUN_LIMESURVEY %}
-- name: limesurvey-configmap
-  files:
-    - plugins/limesurvey/apps/applications/config/config.php
-  options:
-    labels:
-        app.kubernetes.io/name: limesurvey
-{% endif %}

--- a/tutorlimesurvey/plugin.py
+++ b/tutorlimesurvey/plugin.py
@@ -25,7 +25,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("LIMESURVEY_PORT", "80"),
         ("LIMESURVEY_DB_NAME", "limesurvey"),
         ("LIMESURVEY_DB_USER", "limesurvey"),
-        ("LIMESURVEY_CONFIG", ""),
     ]
 )
 

--- a/tutorlimesurvey/templates/limesurvey/apps/application/config/config.php
+++ b/tutorlimesurvey/templates/limesurvey/apps/application/config/config.php
@@ -1,1 +1,0 @@
-{{ LIMESURVEY_CONFIG }}


### PR DESCRIPTION
### Description
This PR removes the option of overriding the config.php file since when initializing the LimeSurvey service, the image entrypoint overrides the config.php either way:

![image](https://github.com/eduNEXT/tutor-contrib-limesurvey/assets/64440265/84ab20ad-1f80-43cc-9c0b-1df9ca6c9a68)
From the output logs of LimeSurvey while initializing. 

When removing the entrypoint, the override is done successfully. I've found another way of customizing the config.php file, by copying the new config file directly onto the image:

https://github.com/eduNEXT/tutor-contrib-limesurvey/blob/MJG/configphp-vol/tutorlimesurvey/templates/limesurvey/build/limesurvey/Dockerfile#L3-L4

But for that to work, we would need to maintain a docker repository & build each time the configuration changes. I propose we close this PR and open an issue tracking a better solution to customize the config.php file.