### PR TITLE
feat: add xblock limesurvey as extra pip requirement

### DIFF
--- a/tutorlimesurvey/plugin.py
+++ b/tutorlimesurvey/plugin.py
@@ -25,6 +25,12 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("LIMESURVEY_PORT", "80"),
         ("LIMESURVEY_DB_NAME", "limesurvey"),
         ("LIMESURVEY_DB_USER", "limesurvey"),
+        (
+            "OPENEDX_EXTRA_PIP_REQUIREMENTS",
+            [
+                "git+https://github.com/eduNEXT/xblock-limesurvey.git@v0.2.3",
+            ],
+        ),
     ]
 )
 


### PR DESCRIPTION
### Description
This PR adds the xblock-limesurvey as an extra pip requirement, so when adding this plugin to a tutor installation, it adds the xblock so it can use the service we're hosting.

### How to test
1. Install this tutor plugin and then enable it
2. Run `tutor config save` 
3. Check the Open edX dockerfile. It should have a line installing the xblock